### PR TITLE
Refactor/back test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,9 @@ dependencies {
     //flyway
     implementation group: 'org.flywaydb', name: 'flyway-core', version: '8.4.1'
 
+    // LocalDateTime
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'

--- a/src/main/java/com/tradin/common/config/RedisConfiguration.java
+++ b/src/main/java/com/tradin/common/config/RedisConfiguration.java
@@ -1,5 +1,6 @@
 package com.tradin.common.config;
 
+import com.tradin.module.history.domain.repository.dao.HistoryDao;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
@@ -9,6 +10,7 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -22,12 +24,20 @@ public class RedisConfiguration {
         return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
     }
 
-    @Bean
+    @Bean(name = "redisTemplate")
     public RedisTemplate<String, Object> redisTemplate() {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
+    }
+
+    @Bean(name = "historyRedisTemplate")
+    public RedisTemplate<String, HistoryDao> historyRedisTemplate() {
+        RedisTemplate<String, HistoryDao> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(HistoryDao.class));
         return redisTemplate;
     }
 }

--- a/src/main/java/com/tradin/module/history/controller/HistoryController.java
+++ b/src/main/java/com/tradin/module/history/controller/HistoryController.java
@@ -23,6 +23,7 @@ public class HistoryController {
     @DisableAuthInSwagger
     @GetMapping("")
     public BackTestResponseDto backTest(@Valid @ModelAttribute BackTestRequestDto request) {
+        System.out.println("여기1");
         return historyService.backTest(request.toServiceDto());
     }
 }

--- a/src/main/java/com/tradin/module/history/controller/HistoryController.java
+++ b/src/main/java/com/tradin/module/history/controller/HistoryController.java
@@ -23,7 +23,6 @@ public class HistoryController {
     @DisableAuthInSwagger
     @GetMapping("")
     public BackTestResponseDto backTest(@Valid @ModelAttribute BackTestRequestDto request) {
-        System.out.println("여기1");
         return historyService.backTest(request.toServiceDto());
     }
 }

--- a/src/main/java/com/tradin/module/history/controller/dto/request/BackTestRequestDto.java
+++ b/src/main/java/com/tradin/module/history/controller/dto/request/BackTestRequestDto.java
@@ -1,5 +1,9 @@
 package com.tradin.module.history.controller.dto.request;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import com.tradin.module.history.service.dto.BackTestDto;
 import com.tradin.module.strategy.domain.TradingType;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -9,7 +13,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @AllArgsConstructor
 @Getter
@@ -20,15 +24,20 @@ public class BackTestRequestDto {
     @NotBlank(message = "StrategyName must not be blank")
     private String name;
 
+    //TODO - LocalDate로 변경하기
     @NotNull(message = "StartDate must not be null")
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    @Schema(description = "시작일", example = "2021-01-01T11:11:11")
-    private LocalDateTime startDate;
+    @JsonSerialize(using = LocalDateSerializer.class)
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @Schema(description = "시작 연,월,일", example = "2021-01-01")
+    private LocalDate startDate;
 
     @NotNull(message = "EndDate must not be null")
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    @Schema(description = "종료일", example = "2021-01-01T11:11:11")
-    private LocalDateTime endDate;
+    @JsonSerialize(using = LocalDateSerializer.class)
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @Schema(description = "종료 연,월,일", example = "2021-01-01")
+    private LocalDate endDate;
 
     @Schema(description = "매매 타입", example = "LONG")
     @NotNull(message = "TradingType must not be null")

--- a/src/main/java/com/tradin/module/history/controller/dto/request/BackTestRequestDto.java
+++ b/src/main/java/com/tradin/module/history/controller/dto/request/BackTestRequestDto.java
@@ -24,7 +24,6 @@ public class BackTestRequestDto {
     @NotBlank(message = "StrategyName must not be blank")
     private String name;
 
-    //TODO - LocalDate로 변경하기
     @NotNull(message = "StartDate must not be null")
     @JsonSerialize(using = LocalDateSerializer.class)
     @JsonDeserialize(using = LocalDateDeserializer.class)

--- a/src/main/java/com/tradin/module/history/domain/repository/dao/HistoryDao.java
+++ b/src/main/java/com/tradin/module/history/domain/repository/dao/HistoryDao.java
@@ -18,7 +18,10 @@ public class HistoryDao {
 
     @JsonCreator
     @QueryProjection
-    public HistoryDao(@JsonProperty("id") Long id, @JsonProperty("entryPosition") Position entryPosition, @JsonProperty("exitPosition") Position exitPosition, @JsonProperty("profitRate") double profitRate) {
+    public HistoryDao(@JsonProperty("id") Long id,
+                      @JsonProperty("entryPosition") Position entryPosition,
+                      @JsonProperty("exitPosition") Position exitPosition,
+                      @JsonProperty("profitRate") double profitRate) {
         this.id = id;
         this.entryPosition = entryPosition;
         this.exitPosition = exitPosition;

--- a/src/main/java/com/tradin/module/history/domain/repository/dao/HistoryDao.java
+++ b/src/main/java/com/tradin/module/history/domain/repository/dao/HistoryDao.java
@@ -1,5 +1,7 @@
 package com.tradin.module.history.domain.repository.dao;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.querydsl.core.annotations.QueryProjection;
 import com.tradin.module.strategy.domain.Position;
 import lombok.Getter;
@@ -14,8 +16,9 @@ public class HistoryDao {
     private final double profitRate;
     private double compoundProfitRate;
 
+    @JsonCreator
     @QueryProjection
-    public HistoryDao(Long id, Position entryPosition, Position exitPosition, double profitRate) {
+    public HistoryDao(@JsonProperty("id") Long id, @JsonProperty("entryPosition") Position entryPosition, @JsonProperty("exitPosition") Position exitPosition, @JsonProperty("profitRate") double profitRate) {
         this.id = id;
         this.entryPosition = entryPosition;
         this.exitPosition = exitPosition;

--- a/src/main/java/com/tradin/module/history/service/HistoryService.java
+++ b/src/main/java/com/tradin/module/history/service/HistoryService.java
@@ -20,6 +20,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import static com.tradin.common.exception.ExceptionMessage.NOT_FOUND_OPEN_POSITION_EXCEPTION;
 import static com.tradin.common.exception.ExceptionMessage.NOT_FOUND_STRATEGY_EXCEPTION;
@@ -85,6 +86,7 @@ public class HistoryService {
 
         for (HistoryDao historyDao : historyDaos) {
             ops.add(cacheKey, historyDao, historyDao.getEntryPosition().getTime().toEpochSecond(ZoneOffset.UTC));
+            historyRedisTemplate.expire(cacheKey, 1, TimeUnit.HOURS);
         }
     }
 

--- a/src/main/java/com/tradin/module/history/service/HistoryService.java
+++ b/src/main/java/com/tradin/module/history/service/HistoryService.java
@@ -19,10 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static com.tradin.common.exception.ExceptionMessage.NOT_FOUND_OPEN_POSITION_EXCEPTION;
 import static com.tradin.common.exception.ExceptionMessage.NOT_FOUND_STRATEGY_EXCEPTION;
@@ -78,7 +75,7 @@ public class HistoryService {
             throw new TradinException(NOT_FOUND_STRATEGY_EXCEPTION);
         }
 
-        return new ArrayList<>(historySet);
+        return new ArrayList<>(Objects.requireNonNull(historySet));
     }
 
 
@@ -94,7 +91,7 @@ public class HistoryService {
 
     private BackTestResponseDto calculateHistoryDaos(List<HistoryDao> historyDaos, BackTestDto request) {
         List<HistoryDao> histories = new ArrayList<>();
-        double compoundProfitRate = 1;
+        double compoundProfitRate = 0;
         double winCount = 0;
         int totalTradeCount = 0;
         double simpleProfitRate = 0;
@@ -106,9 +103,10 @@ public class HistoryService {
                     isCorrespondTradingType(history, request.getTradingType())) {
 
                 totalTradeCount++;
-                compoundProfitRate = compoundProfitRate * (1 + history.getProfitRate());
+                compoundProfitRate = (((1 + compoundProfitRate / 100.0) * (1 + history.getProfitRate() / 100.0)) - 1) * 100;
                 history.setCompoundProfitRate(compoundProfitRate);
                 histories.add(history);
+
 
                 double profitRate = history.getProfitRate();
                 if (profitRate > 0) {

--- a/src/main/java/com/tradin/module/history/service/HistoryService.java
+++ b/src/main/java/com/tradin/module/history/service/HistoryService.java
@@ -51,10 +51,8 @@ public class HistoryService {
     }
 
     public BackTestResponseDto backTest(BackTestDto request) {
-        System.out.println("여기2");
         List<HistoryDao> historyDaos = getHistories(request.getId(), request.getStartDate(), request.getEndDate());
 
-        System.out.println("여기3");
         return calculateHistoryDaos(historyDaos, request);
     }
 
@@ -72,13 +70,11 @@ public class HistoryService {
         Set<HistoryDao> historySet = ops.rangeByScore(cacheKey, startScore, endScore);
 
         if (historySet != null && historySet.isEmpty()) {
-            System.out.println("cache miss");
             addHistory(cacheKey, strategyId);
             historySet = ops.rangeByScore(cacheKey, startScore, endScore);
         }
 
         if (historySet != null && historySet.isEmpty()) {
-            System.out.println("null");
             throw new TradinException(NOT_FOUND_STRATEGY_EXCEPTION);
         }
 
@@ -134,7 +130,6 @@ public class HistoryService {
 
         StrategyInfoDto strategyInfoDto = StrategyInfoDto.of(request.getId(), request.getName(), compoundProfitRate, winRate, profitFactor, totalTradeCount, averageProfitRate);
 
-        System.out.println("여기4");
         return BackTestResponseDto.of(strategyInfoDto, histories);
     }
 

--- a/src/main/java/com/tradin/module/history/service/HistoryService.java
+++ b/src/main/java/com/tradin/module/history/service/HistoryService.java
@@ -133,7 +133,7 @@ public class HistoryService {
 
 
     private double calculateWinRate(double winCount, int totalTradeCount) {
-        return totalTradeCount == 0 ? 0 : winCount / totalTradeCount;
+        return totalTradeCount == 0 ? 0 : winCount / totalTradeCount * 100;
     }
 
     private double calculateAverageProfitRate(double simpleProfitRate, int totalTradeCount) {

--- a/src/main/java/com/tradin/module/history/service/dto/BackTestDto.java
+++ b/src/main/java/com/tradin/module/history/service/dto/BackTestDto.java
@@ -4,19 +4,18 @@ import com.tradin.module.strategy.domain.TradingType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @AllArgsConstructor
 @Getter
 public class BackTestDto {
     private Long id;
     private String name;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private TradingType tradingType;
 
-    public static BackTestDto of(Long id, String name, LocalDateTime startDate, LocalDateTime endDate,
-                                 TradingType tradingType) {
+    public static BackTestDto of(Long id, String name, LocalDate startDate, LocalDate endDate, TradingType tradingType) {
         return new BackTestDto(id, name, startDate, endDate, tradingType);
     }
 }

--- a/src/main/java/com/tradin/module/strategy/domain/Position.java
+++ b/src/main/java/com/tradin/module/strategy/domain/Position.java
@@ -1,5 +1,9 @@
 package com.tradin.module.strategy.domain;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +24,8 @@ public class Position {
     private TradingType tradingType;
 
     @Column(nullable = false)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime time;
 
     @Column(nullable = false)


### PR DESCRIPTION
## 변경사항
- 매매내역 캐시 방식 변경
- 매매내역 캐시에 만료시간 설정
- 수익률 계산법, 승률 표기법 변경

## 상세내용
- 기존 매매내역 캐시 방식은 전체 매매내역 리스트를 캐시한 뒤 시작일과 종료일에 맞게 데이터를 잘라서 계산했음. 하지만 데이터를 정렬해서 자르는데 오버해드가 발생하고, 매매 내역이  추가되면 캐시를 다시 올려야 되는 오버헤드가 발생함
  - 각각의 매매내역을 캐시하는 형태로 변경. ZSet을 사용해서 날짜 범위에 따른 데이터 추출에 유리한 장점이 있음. 하지만 모종의 이유로 시작일과 종료일 사이에 캐시가 삭제되면 수익률이나 승률이 부정확해진다는 단점이 존재함. 이를 해결하기 위해 캐시 만료 시간을 설정하여 이러한 일의 발생을 최소화함.
